### PR TITLE
[BUGFIX] Move description of command line options

### DIFF
--- a/Classes/TYPO3/AccountManagement/Command/AccountCommandController.php
+++ b/Classes/TYPO3/AccountManagement/Command/AccountCommandController.php
@@ -44,10 +44,10 @@ class AccountCommandController extends \TYPO3\Flow\Cli\CommandController {
 	 * @param string $username The username of the user to be created.
 	 * @param string $password Password of the user to be created
 	 * @param string $firstName First name of the user to be created
-	 * @param string $middleName Middle name of the user to be created (optional)
 	 * @param string $lastName Last name of the user to be created
 	 * @param string $roles A comma separated list of roles to assign
-	 * @param string $authenticationProvider The name of the authentication provider to use
+	 * @param string $middleName Middle name of the user to be created (optional)
+	 * @param string $authenticationProvider The name of the authentication provider to use (optional)
 	 * @return void
 	 */
 	public function createCommand($username, $password, $firstName, $lastName, $roles, $middleName='', $authenticationProvider = 'DefaultProvider') {


### PR DESCRIPTION
Flow uses the source code comments to print a description
of all options of a command line action. The comments have
to be in the same order like the arguments passed to
the function.

This is currently not the case for the account:create command.

Rearange the comments to match the existing order
of the argument list.

Before:
![before](https://cloud.githubusercontent.com/assets/1592995/4733171/09ccbcae-59c5-11e4-9705-4f8e1e94d4a8.png)

After:
![after](https://cloud.githubusercontent.com/assets/1592995/4733170/09c80e16-59c5-11e4-9d3d-49af7d80d75a.png)
